### PR TITLE
Fix image scaling to 100% of screen width

### DIFF
--- a/AndBible/assets/web/style.css
+++ b/AndBible/assets/web/style.css
@@ -26,7 +26,7 @@ span[id="0"].verseNo + h1:after {
 }
 
 img.sword {
-	width: 100%;
+	max-width: 100%;
 }
 
 h1 a, .heading2, .heading3, .heading4 {

--- a/AndBible/assets/web/style.css
+++ b/AndBible/assets/web/style.css
@@ -25,6 +25,10 @@ span[id="0"].verseNo + h1:after {
 	white-space: pre; 
 }
 
+img.sword {
+	width: 100%;
+}
+
 h1 a, .heading2, .heading3, .heading4 {
 	color: navy;
 	text-align: left;

--- a/AndBible/src/net/bible/service/format/osistohtml/FigureHandler.java
+++ b/AndBible/src/net/bible/service/format/osistohtml/FigureHandler.java
@@ -37,7 +37,7 @@ public class FigureHandler implements OsisTagHandler {
 		String src = attrs.getValue(OSISUtil.ATTRIBUTE_FIGURE_SRC);
 		
 		if (StringUtils.isNotEmpty(src)) {
-			writer.write("<img src='"+parameters.getModuleBasePath()+"/"+src+"'/>");
+			writer.write("<img class='sword' src='"+parameters.getModuleBasePath()+"/"+src+"'/>");
 		}
 	}
 


### PR DESCRIPTION
Here is a simple fix for image scaling bug https://github.com/mjdenham/and-bible/issues/24 . Scales image to 100% of the screen width. <del>I did not find any CSS support in AndBible so I added CSS style straight into <img> tag.</del>

