### PR TITLE
WIP Show inline reference content always with genbooks and commentaries

### DIFF
--- a/and-bible/app/src/main/java/net/bible/service/format/osistohtml/OsisToHtmlParameters.java
+++ b/and-bible/app/src/main/java/net/bible/service/format/osistohtml/OsisToHtmlParameters.java
@@ -29,7 +29,9 @@ public class OsisToHtmlParameters {
 	private BookmarkStyle defaultBookmarkStyle = BookmarkStyle.YELLOW_STAR;
     private boolean isShowNotes = false;
     private boolean isAutoWrapUnwrappedRefsInNote = false;
-    // used as a basis if a reference has only chapter and no book
+    private boolean isShowReferenceContent = true;
+
+	// used as a basis if a reference has only chapter and no book
     private Verse basisRef;
     private Versification documentVersification;
     private String font;
@@ -118,6 +120,12 @@ public class OsisToHtmlParameters {
 	public void setAutoWrapUnwrappedRefsInNote(boolean isAutoWrapUnwrappedRefsInNote) {
 		this.isAutoWrapUnwrappedRefsInNote = isAutoWrapUnwrappedRefsInNote;
 	}
+    public boolean isShowReferenceContent() {
+		return isShowReferenceContent;
+	}
+	public void setShowReferenceContent(boolean isShowReferenceContent) {
+		this.isShowReferenceContent = isShowReferenceContent;
+	}	
 	public boolean isShowStrongs() {
 		return isShowStrongs;
 	}

--- a/and-bible/app/src/main/java/net/bible/service/format/osistohtml/taghandler/ReferenceHandler.java
+++ b/and-bible/app/src/main/java/net/bible/service/format/osistohtml/taghandler/ReferenceHandler.java
@@ -135,7 +135,8 @@ public class ReferenceHandler implements OsisTagHandler {
 		        boolean isSimpleContent = content.length()<3 && content.length()>0;
 		        Iterator<VerseRange> it = ref.rangeIterator(RestrictionType.CHAPTER);
 		        
-		        if (isSingleVerse && isSimpleContent) {
+		        // For commentaries and general books, it is necessary to show always reference content. 
+		        if (parameters.isShowReferenceContent() || (isSingleVerse && isSimpleContent)) { // single verse range or single verse
 			        // simple verse no e.g. 1 or 2 preceding the actual verse in TSK
 					result.append("<a href='").append(Constants.BIBLE_PROTOCOL).append(":").append(it.next().getOsisRef()).append("'>");
 					result.append(content);

--- a/and-bible/app/src/main/java/net/bible/service/sword/SwordContentFacade.java
+++ b/and-bible/app/src/main/java/net/bible/service/sword/SwordContentFacade.java
@@ -323,6 +323,11 @@ public class SwordContentFacade {
 			osisToHtmlParameters.setDocumentVersification(((AbstractPassageBook)book).getVersification());
 		}
 		
+		// If Bible, do not show reference content. In commentaries and genbooks they need to be shown
+		if (BookCategory.BIBLE.equals(bookCategory)){
+			osisToHtmlParameters.setShowReferenceContent(false);
+		}
+		
 		if (isAndroid) {
 	    	// HunUj has an error in that refs are not wrapped so automatically add notes around refs
 	    	osisToHtmlParameters.setAutoWrapUnwrappedRefsInNote("HunUj".equals(book.getInitials()));


### PR DESCRIPTION
Fixes https://github.com/mjdenham/and-bible/issues/25

From what I understood from our discussion https://groups.google.com/d/msg/and-bible/cSZmdzDU1u0/L9lEaHaCnoQJ, current solution to not show reference content was to fix bible crossreferences in certain bible modules. My solution is essentially the same as in Xulsword, i.e. " But `<reference>` tags which are inline in regular text (such as commentaries) show the reference text as a link."
