### PR TITLE
Improvement / Show full OSIS ID in genbook content list (instead of name)

### DIFF
--- a/and-bible/app/src/main/java/net/bible/android/view/activity/navigation/genbookmap/KeyItemAdapter.java
+++ b/and-bible/app/src/main/java/net/bible/android/view/activity/navigation/genbookmap/KeyItemAdapter.java
@@ -46,7 +46,7 @@ public class KeyItemAdapter extends ArrayAdapter<Key> {
 
 		// Set value for the first text field
 		if (view != null) {
-			String key = item.getName();
+			String key = item.getOsisID();
 			// make all uppercase in Calvin's Institutes look nicer
 			if (ABStringUtils.isAllUpperCaseWherePossible(key)) {
 				key = WordUtils.capitalizeFully(key);


### PR DESCRIPTION
In genbook content list, it is better to show full osis id instead of name, which is only the last part of the osis id. This makes it possible to use content list to get better insight and navigate nested TOC structures.