### PR TITLE
Bugfix / Handle references that contain spaces properly. 

### DIFF
--- a/and-bible/app/src/main/java/net/bible/service/format/osistohtml/taghandler/ReferenceHandler.java
+++ b/and-bible/app/src/main/java/net/bible/service/format/osistohtml/taghandler/ReferenceHandler.java
@@ -88,43 +88,61 @@ public class ReferenceHandler implements OsisTagHandler {
 		writer.clearTempStore();
 		currentRefOsisRef = null;
 	}
+
+	private String getReferenceFromContent(String content) {
+		// JSword does not know the basis (default book) so prepend it if it looks like JSword failed to work it out
+		// We only need to worry about the first ref because JSword uses the first ref as the basis for the subsequent refs
+		// if content starts with a number and is not followed directly by an alpha char e.g. 1Sa
+		String reference = null;
+
+		if (content != null && content.length() > 0 && StringUtils.isNumeric(content.subSequence(0, 1)) &&
+				(content.length() < 2 || !StringUtils.isAlphaSpace(content.subSequence(1, 2)))) {
+
+			// maybe should use VerseRangeFactory.fromstring(orig, basis)
+			// this check for a colon to see if the first ref is verse:chap is not perfect but it will do until JSword adds a fix
+			int firstColonPos = content.indexOf(":");
+			boolean isVerseAndChapter = firstColonPos > 0 && firstColonPos < 4;
+			if (isVerseAndChapter) {
+				reference = parameters.getBasisRef().getBook().getOSIS() + " " + content;
+			} else {
+				reference = parameters.getBasisRef().getBook().getOSIS() + " " + parameters.getBasisRef().getChapter() + ":" + content;
+			}
+			log.debug("Patched reference:" + reference);
+		} else if (content != null){
+			// Avoid urls of type 'matt 3:14' by excluding urns with a space
+			if (content.contains(" ")) {
+				reference = content.replace(":", "/");
+			}
+			else
+				reference = content;
+		}
+		return reference;
+	}
     
     /** create a link tag from an OSISref and the content of the tag
      */
     private String getReferenceTag(String reference, String content) {
     	log.debug("Ref:"+reference+" Content:"+content);
     	StringBuilder result = new StringBuilder();
+    	boolean isFullSwordUrn;
     	try {
-    		
-    		//JSword does not know the basis (default book) so prepend it if it looks like JSword failed to work it out
-    		//We only need to worry about the first ref because JSword uses the first ref as the basis for the subsequent refs
-    		// if content starts with a number and is not followed directly by an alpha char e.g. 1Sa
-    		if (reference==null && content!=null && content.length()>0 && StringUtils.isNumeric(content.subSequence(0,1)) &&
-   				(content.length()<2 || !StringUtils.isAlphaSpace(content.subSequence(1,2)))) {
-    			
-        		// maybe should use VerseRangeFactory.fromstring(orig, basis)
-    			// this check for a colon to see if the first ref is verse:chap is not perfect but it will do until JSword adds a fix
-    			int firstColonPos = content.indexOf(":");
-    			boolean isVerseAndChapter = firstColonPos>0 && firstColonPos<4;
-    			if (isVerseAndChapter) {
-        			reference = parameters.getBasisRef().getBook().getOSIS()+" "+content;
-    			} else {
-    				reference = parameters.getBasisRef().getBook().getOSIS()+" "+parameters.getBasisRef().getChapter()+":"+content;
-    			}
-    			log.debug("Patched reference:"+reference);
-    		} else if (reference==null) {
-    			reference = content;
-    		}
-    		
-    		// convert urns of type book:key to sword://book/key to simplify urn parsing (1 fewer case to check for).  
-    		// Avoid urls of type 'matt 3:14' by excludng urns with a space
-    		if (reference.contains(":") && !reference.contains(" ") && !reference.startsWith("sword://")) {
-    			reference = "sword://"+reference.replace(":", "/");
-    		}
 
-    		boolean isFullSwordUrn = reference.contains("/") && reference.contains(":");
+    		if(reference==null) {
+    			reference = getReferenceFromContent(content);
+    			isFullSwordUrn = false;
+			}
+			else {
+				isFullSwordUrn = reference.contains("/") && reference.contains(":");
+
+				// convert urns of type book:key to sword://book/key to simplify urn parsing (1 fewer case to check for).
+				if (reference.contains(":") && !reference.startsWith("sword://")) {
+					reference = "sword://" + reference.replace(":", "/");
+					isFullSwordUrn = true;
+				}
+			}
+
     		if (isFullSwordUrn) {
-    			// e.g. sword://StrongsRealGreek/01909
+    			// e.g. sword://StrongsRealGreek/01909 or Genbook reference
     			// don't play with the reference - just assume it is correct
 				result.append("<a href='").append(reference).append("'>");
 				result.append(content);

--- a/and-bible/app/src/test/java/net/bible/service/format/osistohtml/taghandler/ReferenceHandlerTest.java
+++ b/and-bible/app/src/test/java/net/bible/service/format/osistohtml/taghandler/ReferenceHandlerTest.java
@@ -66,7 +66,27 @@ public class ReferenceHandlerTest {
 		
 		assertThat(writer.getHtml(), equalTo("(<a href='bible:Exod.15.1'>Exodus 15:1-19</a>.)"));
 	}
-	
+
+	/**
+	 * When there is no osis ref the content is used if it is a valid reference
+	 */
+
+	@Test
+	public void testGenBookUrlWithSpace() {
+		writer.write("(");
+
+		AttributesImpl attrs = new AttributesImpl();
+		attrs.addAttribute(null, null, OSISUtil.OSIS_ATTR_REF, null, "ESV Study Bible Articles:Book introductions");
+		referenceHandler.start(attrs);
+
+		writer.write("Some content");
+
+		referenceHandler.end();
+		writer.write(".)");
+
+		assertThat(writer.getHtml(), equalTo("(<a href='sword://ESV Study Bible Articles/Book introductions'>Some content</a>.)"));
+	}
+
 	/**
 	 * When there is no osis ref the content is used if it is a valid reference
 	 */


### PR DESCRIPTION
Spaces are allowed in general book references.This fix was part of https://github.com/mjdenham/and-bible/pull/28. It still had some issues and broken tests. This PR has fixed the issues and I also added test about the broken feature.

Refactored code a little (getReferenceFromContent method)

