### PR TITLE
Feature/Add new split mode preference (vertical, horizontal, automatic) to preferences screen

### DIFF
--- a/and-bible/app/src/main/java/net/bible/android/view/activity/page/screen/DocumentWebViewBuilder.java
+++ b/and-bible/app/src/main/java/net/bible/android/view/activity/page/screen/DocumentWebViewBuilder.java
@@ -66,7 +66,7 @@ public class DocumentWebViewBuilder {
 
 	private final WindowControl windowControl;
 
-	private boolean isLaidOutForPortrait;
+	private boolean isLaidOutWithHorizontalSplit;
 	private final MainBibleActivity mainBibleActivity;
 
 	private final BibleViewFactory bibleViewFactory;
@@ -85,7 +85,6 @@ public class DocumentWebViewBuilder {
 	final static private String SPLIT_MODE_HORIZONTAL = "horizontal";
 
 	private LinearLayout previousParent;
-	private boolean verticalSplit = true;
 
 	private static final String TAG="DocumentWebViewBuilder";
 
@@ -152,7 +151,7 @@ public class DocumentWebViewBuilder {
 
     	if (!isWebView || 
     			isWindowConfigurationChanged ||
-    			splitHorizontally!=isLaidOutForPortrait) {
+    			splitHorizontally!= isLaidOutWithHorizontalSplit) {
     		Log.d(TAG, "Layout web view");
     		
     		List<Window> windows = windowControl.getWindowRepository().getVisibleWindows();
@@ -229,7 +228,7 @@ public class DocumentWebViewBuilder {
     		}    		
     		
     		previousParent = parent;
-    		isLaidOutForPortrait = splitHorizontally;
+    		isLaidOutWithHorizontalSplit = splitHorizontally;
     		isWindowConfigurationChanged = false;
     	}
 	}

--- a/and-bible/app/src/main/res/values/arrays.xml
+++ b/and-bible/app/src/main/res/values/arrays.xml
@@ -28,7 +28,7 @@
 		<item>automatic</item>
 	</string-array>
 
-	<!-- Screen colors: automatic night mode, day, night -->
+	<!-- Split mode: vertical, horizontal, automatic -->
 	<string-array name="prefs_split_mode_descriptions">
 		<item>@string/prefs_split_mode_vertical</item>
 		<item>@string/prefs_split_mode_horizontal</item>

--- a/and-bible/app/src/main/res/values/arrays.xml
+++ b/and-bible/app/src/main/res/values/arrays.xml
@@ -28,6 +28,19 @@
 		<item>automatic</item>
 	</string-array>
 
+	<!-- Screen colors: automatic night mode, day, night -->
+	<string-array name="prefs_split_mode_descriptions">
+		<item>@string/prefs_split_mode_vertical</item>
+		<item>@string/prefs_split_mode_horizontal</item>
+		<item>@string/prefs_split_mode_automatic</item>
+	</string-array>
+	<string-array name="prefs_split_mode_values">
+		<item>vertical</item>
+		<item>horizontal</item>
+		<item>automatic</item>
+	</string-array>
+
+
 	<!-- These languages must be in the same order as the language codes below -->
 	<string-array name="prefs_interface_locale_descriptions">
 		<item>@string/lang_default</item>
@@ -129,5 +142,5 @@
 		<item>vi</item>
 		<item>zh</item>
 	</string-array>
-		
+
 </resources>

--- a/and-bible/app/src/main/res/values/strings.xml
+++ b/and-bible/app/src/main/res/values/strings.xml
@@ -121,6 +121,10 @@ TODO: error and download_document_confirm_prefix need to be parameterized rather
     <string name="speak_speed_normal">Normal</string>
     <string name="speak_speed_fast">Fast</string>
 
+    <string name="prefs_split_mode_vertical">Vertical</string>
+    <string name="prefs_split_mode_horizontal">Horizontal</string>
+    <string name="prefs_split_mode_automatic">Automatic</string>
+
     <!-- Window -->
     <string name="window">Window</string>
     <string name="windowClose">Close</string>

--- a/and-bible/app/src/main/res/values/strings.xml
+++ b/and-bible/app/src/main/res/values/strings.xml
@@ -125,6 +125,9 @@ TODO: error and download_document_confirm_prefix need to be parameterized rather
     <string name="prefs_split_mode_horizontal">Horizontal</string>
     <string name="prefs_split_mode_automatic">Automatic</string>
 
+    <string name="prefs_split_mode_summary">How to split multiple screens on the window layout?</string>
+    <string name="prefs_split_mode_title">Split mode</string>
+
     <!-- Window -->
     <string name="window">Window</string>
     <string name="windowClose">Close</string>

--- a/and-bible/app/src/main/res/xml/settings.xml
+++ b/and-bible/app/src/main/res/xml/settings.xml
@@ -81,6 +81,12 @@
 				android:title="@string/prefs_open_links_in_special_window_title"
 				android:summary="@string/prefs_open_links_in_special_window_summary"
 				android:defaultValue="true"/>
+	<ListPreference android:key="split_mode_pref"
+				android:title="Split mode"
+				android:summary="How to split multiple screens on the window layout?"
+				android:entries="@array/prefs_split_mode_descriptions"
+				android:entryValues="@array/prefs_split_mode_values"
+				android:defaultValue="automatic"/>
 	<ListPreference android:key="screen_timeout_pref"
 				android:title="@string/prefs_screen_timeout_title"
 				android:summary="@string/prefs_screen_timeout_summary"

--- a/and-bible/app/src/main/res/xml/settings.xml
+++ b/and-bible/app/src/main/res/xml/settings.xml
@@ -82,8 +82,8 @@
 				android:summary="@string/prefs_open_links_in_special_window_summary"
 				android:defaultValue="true"/>
 	<ListPreference android:key="split_mode_pref"
-				android:title="Split mode"
-				android:summary="How to split multiple screens on the window layout?"
+				android:title="@string/prefs_split_mode_title"
+				android:summary="@string/prefs_split_mode_summary"
 				android:entries="@array/prefs_split_mode_descriptions"
 				android:entryValues="@array/prefs_split_mode_values"
 				android:defaultValue="automatic"/>


### PR DESCRIPTION
Currently split mode is determined by if the mobile device is used in portrait or landscape mode.
Sometimes it is more desirable to manually select desired split mode to be vertical even in portrait mode or horizontal in landscape mode. This pull request implements the new preference which allows user to chooce desired behavior. Default is 'automatic', which corresponds to current behavior.

## Demo screenshots. Split mode set to 'vertical':
![screenshot_1522235780](https://user-images.githubusercontent.com/5811789/38025921-ce549cf0-3292-11e8-99c4-800a92155663.png)

## New split mode preference:
![screenshot_1522235794](https://user-images.githubusercontent.com/5811789/38025935-d72a70b6-3292-11e8-86bc-4fcb322bfe90.png)

## Split mode preference selection:
![screenshot_1522235800](https://user-images.githubusercontent.com/5811789/38025936-d7ac5662-3292-11e8-9f48-ac75ab2f1fee.png)
