### PR TITLE
Bugfix/reference contents should be displayed

### DIFF
--- a/and-bible/app/src/main/java/net/bible/service/format/osistohtml/taghandler/ReferenceHandler.java
+++ b/and-bible/app/src/main/java/net/bible/service/format/osistohtml/taghandler/ReferenceHandler.java
@@ -88,43 +88,61 @@ public class ReferenceHandler implements OsisTagHandler {
 		writer.clearTempStore();
 		currentRefOsisRef = null;
 	}
+
+	private String getReferenceFromContent(String content) {
+		// JSword does not know the basis (default book) so prepend it if it looks like JSword failed to work it out
+		// We only need to worry about the first ref because JSword uses the first ref as the basis for the subsequent refs
+		// if content starts with a number and is not followed directly by an alpha char e.g. 1Sa
+		String reference = null;
+
+		if (content != null && content.length() > 0 && StringUtils.isNumeric(content.subSequence(0, 1)) &&
+				(content.length() < 2 || !StringUtils.isAlphaSpace(content.subSequence(1, 2)))) {
+
+			// maybe should use VerseRangeFactory.fromstring(orig, basis)
+			// this check for a colon to see if the first ref is verse:chap is not perfect but it will do until JSword adds a fix
+			int firstColonPos = content.indexOf(":");
+			boolean isVerseAndChapter = firstColonPos > 0 && firstColonPos < 4;
+			if (isVerseAndChapter) {
+				reference = parameters.getBasisRef().getBook().getOSIS() + " " + content;
+			} else {
+				reference = parameters.getBasisRef().getBook().getOSIS() + " " + parameters.getBasisRef().getChapter() + ":" + content;
+			}
+			log.debug("Patched reference:" + reference);
+		} else if (content != null){
+			// Avoid urls of type 'matt 3:14' by excluding urns with a space
+			if (content.contains(" ")) {
+				reference = content.replace(":", "/");
+			}
+			else
+				reference = content;
+		}
+		return reference;
+	}
     
     /** create a link tag from an OSISref and the content of the tag
      */
     private String getReferenceTag(String reference, String content) {
     	log.debug("Ref:"+reference+" Content:"+content);
     	StringBuilder result = new StringBuilder();
+    	boolean isFullSwordUrn;
     	try {
-    		
-    		//JSword does not know the basis (default book) so prepend it if it looks like JSword failed to work it out
-    		//We only need to worry about the first ref because JSword uses the first ref as the basis for the subsequent refs
-    		// if content starts with a number and is not followed directly by an alpha char e.g. 1Sa
-    		if (reference==null && content!=null && content.length()>0 && StringUtils.isNumeric(content.subSequence(0,1)) &&
-   				(content.length()<2 || !StringUtils.isAlphaSpace(content.subSequence(1,2)))) {
-    			
-        		// maybe should use VerseRangeFactory.fromstring(orig, basis)
-    			// this check for a colon to see if the first ref is verse:chap is not perfect but it will do until JSword adds a fix
-    			int firstColonPos = content.indexOf(":");
-    			boolean isVerseAndChapter = firstColonPos>0 && firstColonPos<4;
-    			if (isVerseAndChapter) {
-        			reference = parameters.getBasisRef().getBook().getOSIS()+" "+content;
-    			} else {
-    				reference = parameters.getBasisRef().getBook().getOSIS()+" "+parameters.getBasisRef().getChapter()+":"+content;
-    			}
-    			log.debug("Patched reference:"+reference);
-    		} else if (reference==null) {
-    			reference = content;
-    		}
-    		
-    		// convert urns of type book:key to sword://book/key to simplify urn parsing (1 fewer case to check for).  
-    		// Avoid urls of type 'matt 3:14' by excludng urns with a space
-    		if (reference.contains(":") && !reference.contains(" ") && !reference.startsWith("sword://")) {
-    			reference = "sword://"+reference.replace(":", "/");
-    		}
 
-    		boolean isFullSwordUrn = reference.contains("/") && reference.contains(":");
+    		if(reference==null) {
+    			reference = getReferenceFromContent(content);
+    			isFullSwordUrn = false;
+			}
+			else {
+				isFullSwordUrn = reference.contains("/") && reference.contains(":");
+
+				// convert urns of type book:key to sword://book/key to simplify urn parsing (1 fewer case to check for).
+				if (reference.contains(":") && !reference.startsWith("sword://")) {
+					reference = "sword://" + reference.replace(":", "/");
+					isFullSwordUrn = true;
+				}
+			}
+
     		if (isFullSwordUrn) {
-    			// e.g. sword://StrongsRealGreek/01909
+    			// e.g. sword://StrongsRealGreek/01909 or Genbook reference
     			// don't play with the reference - just assume it is correct
 				result.append("<a href='").append(reference).append("'>");
 				result.append(content);

--- a/and-bible/app/src/main/java/net/bible/service/format/osistohtml/taghandler/ReferenceHandler.java
+++ b/and-bible/app/src/main/java/net/bible/service/format/osistohtml/taghandler/ReferenceHandler.java
@@ -151,15 +151,19 @@ public class ReferenceHandler implements OsisTagHandler {
 		        Passage ref = (Passage) PassageKeyFactory.instance().getKey(parameters.getDocumentVersification(), reference);
 		        boolean isSingleVerse = ref.countVerses()==1;
 		        boolean hasContent = content.length()>0;
-		        Iterator<VerseRange> it = ref.rangeIterator(RestrictionType.CHAPTER);
-		        
-		        if (isSingleVerse && hasContent) {
-			        // simple verse no e.g. 1 or 2 preceding the actual verse in TSK
+				boolean hasSeparateRefs = reference.contains(" ");
+				boolean isSingleRange = !isSingleVerse && !hasSeparateRefs;
+
+
+		        if ((isSingleVerse || isSingleRange) && hasContent) {
+					// simple verse no e.g. 1 or 2 preceding the actual verse in TSK
+					Iterator<VerseRange> it = ref.rangeIterator(RestrictionType.NONE);
 					result.append("<a href='").append(Constants.BIBLE_PROTOCOL).append(":").append(it.next().getOsisRef()).append("'>");
 					result.append(content);
 					result.append("</a>");
-		        } else {
+				} else {
 		        	// multiple complex references
+					Iterator<VerseRange> it = ref.rangeIterator(RestrictionType.CHAPTER);
 		        	boolean isFirst = true;
 					while (it.hasNext()) {
 						Key key = it.next();

--- a/and-bible/app/src/main/java/net/bible/service/format/osistohtml/taghandler/ReferenceHandler.java
+++ b/and-bible/app/src/main/java/net/bible/service/format/osistohtml/taghandler/ReferenceHandler.java
@@ -150,10 +150,10 @@ public class ReferenceHandler implements OsisTagHandler {
     		} else {
 		        Passage ref = (Passage) PassageKeyFactory.instance().getKey(parameters.getDocumentVersification(), reference);
 		        boolean isSingleVerse = ref.countVerses()==1;
-		        boolean isSimpleContent = content.length()<3 && content.length()>0;
+		        boolean hasContent = content.length()>0;
 		        Iterator<VerseRange> it = ref.rangeIterator(RestrictionType.CHAPTER);
 		        
-		        if (isSingleVerse && isSimpleContent) {
+		        if (isSingleVerse && hasContent) {
 			        // simple verse no e.g. 1 or 2 preceding the actual verse in TSK
 					result.append("<a href='").append(Constants.BIBLE_PROTOCOL).append(":").append(it.next().getOsisRef()).append("'>");
 					result.append(content);

--- a/and-bible/app/src/test/java/net/bible/service/format/osistohtml/taghandler/ReferenceHandlerTest.java
+++ b/and-bible/app/src/test/java/net/bible/service/format/osistohtml/taghandler/ReferenceHandlerTest.java
@@ -64,7 +64,7 @@ public class ReferenceHandlerTest {
 		referenceHandler.end();
 		writer.write(".)");
 		
-		assertThat(writer.getHtml(), equalTo("(<a href='bible:Exod.15.1'>Exodus 15:1-19</a>.)"));
+		assertThat(writer.getHtml(), equalTo("(<a href='bible:Exod.15.1-Exod.15.19'>Ex. 15:1-19</a>.)"));
 	}
 
 	/**
@@ -106,7 +106,7 @@ public class ReferenceHandlerTest {
 	}
 
 	@Test
-	public void testReferenceContent() {
+	public void testReferenceContentSingleRef() {
 		AttributesImpl attrs = new AttributesImpl();
 		attrs.addAttribute(null, null, OSISUtil.OSIS_ATTR_REF, null, "Ps.121.2");
 		referenceHandler.start(attrs);
@@ -117,6 +117,34 @@ public class ReferenceHandlerTest {
 
 		// note that just the first verse in each range is referenced - it might be better to reference the whole range although the final navigation when pressed would be ifentical
 		assertThat(writer.getHtml(), equalTo("<a href='bible:Ps.121.2'>121:2</a>"));
+	}
+
+	@Test
+	public void testReferenceContentWithSingleRange() {
+		AttributesImpl attrs = new AttributesImpl();
+		attrs.addAttribute(null, null, OSISUtil.OSIS_ATTR_REF, null, "Gen.1.1-Gen.2.1");
+		referenceHandler.start(attrs);
+
+		writer.write("1:1-2:1");
+
+		referenceHandler.end();
+
+		// note that just the first verse in each range is referenced - it might be better to reference the whole range although the final navigation when pressed would be ifentical
+		assertThat(writer.getHtml(), equalTo("<a href='bible:Gen.1-Gen.2.1'>1:1-2:1</a>"));
+	}
+
+	@Test
+	public void testReferenceContentWithSingleRange2() {
+		AttributesImpl attrs = new AttributesImpl();
+		attrs.addAttribute(null, null, OSISUtil.OSIS_ATTR_REF, null, "Gen.1.2-Gen.2.1");
+		referenceHandler.start(attrs);
+
+		writer.write("1:2-2:1");
+
+		referenceHandler.end();
+
+		// note that just the first verse in each range is referenced - it might be better to reference the whole range although the final navigation when pressed would be ifentical
+		assertThat(writer.getHtml(), equalTo("<a href='bible:Gen.1.2-Gen.2.1'>1:2-2:1</a>"));
 	}
 
 	/**

--- a/and-bible/app/src/test/java/net/bible/service/format/osistohtml/taghandler/ReferenceHandlerTest.java
+++ b/and-bible/app/src/test/java/net/bible/service/format/osistohtml/taghandler/ReferenceHandlerTest.java
@@ -66,7 +66,27 @@ public class ReferenceHandlerTest {
 		
 		assertThat(writer.getHtml(), equalTo("(<a href='bible:Exod.15.1'>Exodus 15:1-19</a>.)"));
 	}
-	
+
+	/**
+	 * When there is no osis ref the content is used if it is a valid reference
+	 */
+
+	@Test
+	public void testGenBookUrlWithSpace() {
+		writer.write("(");
+
+		AttributesImpl attrs = new AttributesImpl();
+		attrs.addAttribute(null, null, OSISUtil.OSIS_ATTR_REF, null, "ESV Study Bible Articles:Book introductions");
+		referenceHandler.start(attrs);
+
+		writer.write("Some content");
+
+		referenceHandler.end();
+		writer.write(".)");
+
+		assertThat(writer.getHtml(), equalTo("(<a href='sword://ESV Study Bible Articles/Book introductions'>Some content</a>.)"));
+	}
+
 	/**
 	 * When there is no osis ref the content is used if it is a valid reference
 	 */

--- a/and-bible/app/src/test/java/net/bible/service/format/osistohtml/taghandler/ReferenceHandlerTest.java
+++ b/and-bible/app/src/test/java/net/bible/service/format/osistohtml/taghandler/ReferenceHandlerTest.java
@@ -105,6 +105,20 @@ public class ReferenceHandlerTest {
 		assertThat(writer.getHtml(), equalTo("(<a href='bible:Exod.15.1'>Exodus 15:1-19</a>.)"));
 	}
 
+	@Test
+	public void testReferenceContent() {
+		AttributesImpl attrs = new AttributesImpl();
+		attrs.addAttribute(null, null, OSISUtil.OSIS_ATTR_REF, null, "Ps.121.2");
+		referenceHandler.start(attrs);
+
+		writer.write("121:2");
+
+		referenceHandler.end();
+
+		// note that just the first verse in each range is referenced - it might be better to reference the whole range although the final navigation when pressed would be ifentical
+		assertThat(writer.getHtml(), equalTo("<a href='bible:Ps.121.2'>121:2</a>"));
+	}
+
 	/**
 	 * Test long complex ref from TSk Psa 118:2
 	 * Ref:Ps.115.9-Ps.115.11 Ps.135.19-Ps.135.20 Ps.145.10 Ps.147.19-Ps.147.20 Gal.6.16 Heb.13.15 Content:115:9-11; 135:19,20; 145:10; 147:19,20; Ga 6:16; Heb 13:15 
@@ -157,7 +171,7 @@ public class ReferenceHandlerTest {
 		referenceHandler.start(attrs);
 		writer.write("2:9");
 		referenceHandler.end();
-		assertThat(writer.getHtml(), equalTo("<a href='bible:Gal.2.9'>Galatians 2:9</a>"));
+		assertThat(writer.getHtml(), equalTo("<a href='bible:Gal.2.9'>2:9</a>"));
 	}
 	
 	/**
@@ -209,23 +223,6 @@ public class ReferenceHandlerTest {
 		referenceHandler.end();
 		
 		assertThat(writer.getHtml(), equalTo("<a href='bible:Gal.1.6'>6</a>"));
-	}
-
-	/**
-	 * ref = single verse.  Content is complex e.g. 'Matt 1:2'.
-	 * I am not sure why this is handled differently to the single verse short content
-	 */
-	@Test
-	public void testSingleVerseLongContent() {
-		AttributesImpl attrs = new AttributesImpl();
-		attrs.addAttribute(null, null, OSISUtil.OSIS_ATTR_REF, null, "Gal.1.6");		
-		referenceHandler.start(attrs);
-
-		writer.write("Galatians 1 verse 6");
-
-		referenceHandler.end();
-		
-		assertThat(writer.getHtml(), equalTo("<a href='bible:Gal.1.6'>Galatians 1:6</a>"));
 	}
 
 	/**


### PR DESCRIPTION
New approach to #28 . Work is based on #110 (i.e. this PR contains changes of #110 too). To see only differences in this PR, see https://github.com/tuomas2/and-bible/pull/1. 

Tested with Gill, which works as earlier. Checked also unit tests + added a new test for this. 

Demo by screenshots:

## Current behavior rewrites reference contents always (bad):

![screenshot_1522247397](https://user-images.githubusercontent.com/5811789/38035839-ee7e84a8-32ad-11e8-90e5-d7f9343fddf5.png)

## New behavior does not....

![screenshot_1523171719](https://user-images.githubusercontent.com/5811789/38464391-d70d2804-3b15-11e8-8ea7-bfc0060ef2b2.png)

## ... unless there are multiple links in the reference (like in Gill)

![screenshot_1522247621](https://user-images.githubusercontent.com/5811789/38035938-2e4f72f4-32ae-11e8-8e23-ca7479aca61b.png)

