### PR TITLE
Improvement / Add proper title that shows module install progress status to install zip view

### DIFF
--- a/and-bible/app/src/main/java/net/bible/android/view/activity/installzip/InstallZip.java
+++ b/and-bible/app/src/main/java/net/bible/android/view/activity/installzip/InstallZip.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
+import android.widget.TextView;
 import net.bible.android.activity.R;
 import net.bible.android.view.activity.download.Download;
 
@@ -189,11 +190,11 @@ class ZipHandler extends AsyncTask<Void, Integer, Integer> {
 	@Override
 	protected void onProgressUpdate(Integer... values) {
 		if (values[0] == 1)
-			parent.setTitle(R.string.extracting_zip_file);
-		int progress_now = (int) Math
+			parent.title.setText(R.string.extracting_zip_file);
+		int progressNow = (int) Math
 				.round(((float) values[0] / (float) total_entries)
 						* parent.progressBar.getMax());
-		parent.progressBar.setProgress(progress_now);
+		parent.progressBar.setProgress(progressNow);
 	}
 }
 
@@ -202,6 +203,7 @@ public class InstallZip extends Activity {
 	static final String TAG = "InstallZip";
 	private static final int PICK_FILE = 1;
 	public ProgressBar progressBar;
+	public TextView title;
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
@@ -209,6 +211,7 @@ public class InstallZip extends Activity {
 		Log.i(TAG, "Install from Zip starting");
 		setContentView(R.layout.activity_install_zip);
 		progressBar = (ProgressBar) findViewById(R.id.progressBar);
+		title = (TextView) findViewById(R.id.installZipLabel);
 		Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
 		intent.setType("*/*");
 		startActivityForResult(intent, PICK_FILE);
@@ -220,7 +223,7 @@ public class InstallZip extends Activity {
 		case PICK_FILE:
 			if (resultCode == RESULT_OK) {
 				Uri uri = data.getData();
-				setTitle(R.string.checking_zip_file);
+				title.setText(R.string.checking_zip_file);
 				ZipHandler zh = new ZipHandler(uri, this);
 				zh.execute();
 			}

--- a/and-bible/app/src/main/res/layout/activity_install_zip.xml
+++ b/and-bible/app/src/main/res/layout/activity_install_zip.xml
@@ -4,6 +4,15 @@
     android:layout_height="match_parent"
     tools:context="${relativePackage}.${activityClass}" >
 
+    <TextView
+            android:text="@string/install_zip_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="26dp"
+            android:id="@+id/installZipLabel"
+            android:layout_alignParentTop="true"
+            android:layout_alignParentLeft="true"
+            android:layout_alignParentStart="true"/>
     <ProgressBar
         android:id="@+id/progressBar"
         style="?android:attr/progressBarStyleHorizontal"
@@ -14,5 +23,4 @@
         android:layout_marginTop="63dp"
         android:max="10000"
         android:progress="0" />
-
 </RelativeLayout>

--- a/and-bible/app/src/main/res/values/strings.xml
+++ b/and-bible/app/src/main/res/values/strings.xml
@@ -168,7 +168,8 @@ TODO: error and download_document_confirm_prefix need to be parameterized rather
     <string name="checking_zip_file">Checking given file...</string>
     <string name="invalid_module">File does not contain a valid SWORD module</string>
     <string name="module_already_installed">File contains a module that is already installed</string>
-    
+    <string name="install_zip_title">Please wait. Loading Zip file.</string>
+
     <!-- Daily Reading Plan -->
     <string name="rdg_plan_title">Reading Plan</string>
     <string name="rdg_plan_selector_title">Choose a Reading Plan</string>


### PR DESCRIPTION
Install Zip view has been missing title that explains what's happening right now. If the module is being downloaded from google drive for example, it might leave the user confused if anything at all is happening.
Now it will explain.

## Before:

![screenshot_1522394141](https://user-images.githubusercontent.com/5811789/38128458-524b88e0-3403-11e8-9caf-74c4a95199f7.png)

## After:

![screenshot_1522393908](https://user-images.githubusercontent.com/5811789/38128326-c933c18a-3402-11e8-8649-1a59c28b622f.png)
