### PR TITLE
Display date bookmark was added in the bookmark list 

### DIFF
--- a/and-bible/app/src/main/java/net/bible/android/view/activity/bookmark/BookmarkItemAdapter.java
+++ b/and-bible/app/src/main/java/net/bible/android/view/activity/bookmark/BookmarkItemAdapter.java
@@ -3,6 +3,7 @@ package net.bible.android.view.activity.bookmark;
 import android.content.Context;
 import android.graphics.Color;
 import android.os.Build;
+import android.text.format.DateFormat;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -12,7 +13,7 @@ import android.widget.ArrayAdapter;
 import net.bible.android.activity.R;
 import net.bible.android.control.bookmark.BookmarkControl;
 import net.bible.android.view.activity.base.ListActionModeHelper;
-import net.bible.android.view.util.widget.TwoLineListItem;
+import net.bible.android.view.util.widget.TwoLine2TitleListItem;
 import net.bible.service.common.CommonUtils;
 import net.bible.service.db.bookmark.BookmarkDto;
 
@@ -48,18 +49,24 @@ public class BookmarkItemAdapter extends ArrayAdapter<BookmarkDto> {
 		BookmarkDto item = getItem(position);
 
 		// Pick up the TwoLineListItem defined in the xml file
-		TwoLineListItem view;
+		TwoLine2TitleListItem view;
 		if (convertView == null) {
 			LayoutInflater inflater = (LayoutInflater) getContext().getSystemService(Context.LAYOUT_INFLATER_SERVICE);
-			view = (TwoLineListItem) inflater.inflate(resource, parent, false);
+			view = (TwoLine2TitleListItem) inflater.inflate(resource, parent, false);
 		} else {
-			view = (TwoLineListItem) convertView;
+			view = (TwoLine2TitleListItem) convertView;
 		}
 
 		// Set value for the first text field
 		if (view.getText1() != null) {
 			String key = bookmarkControl.getBookmarkVerseKey(item);
 			view.getText1().setText(key);
+		}
+
+		// Set value for the date text field
+		if (view.getText3() != null) {
+			String sDt =  DateFormat.format("yyyy-MM-dd hh:mm", item.getCreatedOn()).toString();
+			view.getText3().setText(sDt);
 		}
 
 		// set value for the second text field

--- a/and-bible/app/src/main/java/net/bible/android/view/activity/bookmark/Bookmarks.java
+++ b/and-bible/app/src/main/java/net/bible/android/view/activity/bookmark/Bookmarks.java
@@ -52,7 +52,8 @@ public class Bookmarks extends ListActivityBase implements ListActionModeHelper.
 
 	private ListActionModeHelper listActionModeHelper;
 
-	private static final int LIST_ITEM_TYPE = R.layout.list_item_2_highlighted;
+	//private static final int LIST_ITEM_TYPE = R.layout.list_item_2_highlighted;
+	private static final int LIST_ITEM_TYPE = R.layout.list_item_3_highlighted;
 	private static final String TAG = "Bookmarks";
 
     /** Called when the activity is first created. */

--- a/and-bible/app/src/main/java/net/bible/android/view/util/widget/TwoLine2TitleListItem.java
+++ b/and-bible/app/src/main/java/net/bible/android/view/util/widget/TwoLine2TitleListItem.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2006 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.bible.android.view.util.widget;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.widget.RelativeLayout;
+import android.widget.TextView;
+
+import net.bible.android.activity.R;
+
+/**
+ * <p>A view group with two children, intended for use in ListViews. This item has two 
+ * {@link TextView TextViews} elements (or subclasses) with the ID values
+ * {@link android.R.id#text1 text1}
+ * and {@link android.R.id#text2 text2}. There is an optional third View element with the
+ * ID {@link android.R.id#selectedIcon selectedIcon}, which can be any View subclass
+ * (though it is typically a graphic View, such as {@link android.widget.ImageView ImageView})
+ * that can be displayed when a TwoLineListItem has focus. Android supplies a
+ * {@link android.R.layout#two_line_list_item standard layout resource for TwoLineListView}
+ * (which does not include a selected item icon), but you can design your own custom XML
+ * layout for this object.
+ *
+ * @author Martin Denham [mjdenham at gmail dot com]
+ * @see gnu.lgpl.License for license details.<br>
+ *      The copyright to this program is held by it's author.
+ */
+public class TwoLine2TitleListItem extends RelativeLayout {
+
+    private TextView mText1;
+    private TextView mText2;
+    private TextView mText3;
+
+    public TwoLine2TitleListItem(Context context) {
+        this(context, null, 0);
+    }
+
+    public TwoLine2TitleListItem(Context context, AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public TwoLine2TitleListItem(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+
+//        final TypedArray a = context.obtainStyledAttributes(
+//                attrs, R.styleable.TwoLineListItem);
+//
+//        a.recycle();
+    }
+
+    @Override
+    protected void onFinishInflate() {
+        super.onFinishInflate();
+        
+        mText1 = (TextView) findViewById(R.id.text1);
+        mText2 = (TextView) findViewById(R.id.text2);
+        mText3 = (TextView) findViewById(R.id.text3);
+    }
+    
+    /**
+     * Returns a handle to the item with ID text1.
+     * @return A handle to the item with ID text1.
+     */
+    public TextView getText1() {
+        return mText1;
+    }
+    
+    /**
+     * Returns a handle to the item with ID text2.
+     * @return A handle to the item with ID text2.
+     */
+    public TextView getText2() {
+        return mText2;
+    }
+
+    public TextView getText3() {
+        return mText3;
+    }
+    @Override
+    public CharSequence getAccessibilityClassName() {
+        return TwoLine2TitleListItem.class.getName();
+    }
+}

--- a/and-bible/app/src/main/res/layout/list_item_3_highlighted.xml
+++ b/and-bible/app/src/main/res/layout/list_item_3_highlighted.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<net.bible.android.view.util.widget.TwoLine2TitleListItem xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:minHeight="60dp"
+    android:mode="twoLine"
+    android:paddingLeft="16dp"
+    android:paddingRight="16dp"
+    android:background="@drawable/selectable_background">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical" >
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:orientation="horizontal" >
+
+            <TextView android:id="@+id/text1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textAppearance="?attr/textAppearanceListItem" />
+
+            <TextView android:id="@+id/text3"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:gravity="end"
+                />
+        </LinearLayout>
+
+        <TextView android:id="@+id/text2"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAppearance="?android:textAppearanceSmall" />
+    </LinearLayout>
+
+</net.bible.android.view.util.widget.TwoLine2TitleListItem>


### PR DESCRIPTION
This suggested change shows the date a bookmark was added in the bookmark list. This is one of the changes suggested in [bookmark-improvements](https://github.com/mjdenham/and-bible/pull/111).

Example: See the date on the right below. (Note that the translation is also shown here - this is not added by this pull, but by another pull request)

![image](https://user-images.githubusercontent.com/37398767/38777902-51127cb8-40b0-11e8-9e09-3a1bb1ab8858.png)
