### PR TITLE
Allows refreshing of an existing bookmark's date to the current time when reselected.

### DIFF
--- a/and-bible/app/src/main/java/net/bible/android/control/bookmark/BookmarkControl.java
+++ b/and-bible/app/src/main/java/net/bible/android/control/bookmark/BookmarkControl.java
@@ -65,7 +65,7 @@ public class BookmarkControl {
 		LABEL_UNLABELLED = new LabelDto(-998L, resourceProvider.getString(R.string.label_unlabelled), null);
 	}
 
-	public boolean toggleBookmarkForVerseRange(VerseRange verseRange) {
+	public boolean toggleBookmarkForVerseRange(int menuItemId, VerseRange verseRange) {
 		boolean bOk = false;
 		if (isCurrentDocumentBookmarkable()) {
 
@@ -78,7 +78,8 @@ public class BookmarkControl {
 				} else {
 					Dialogs.getInstance().showErrorMsg(R.string.error_occurred);
 				}
-			} else {
+			}
+			if ((bookmarkDto ==null) || (menuItemId == R.id.add_bookmark)) {
 				// prepare new bookmark and add to db
 				bookmarkDto = new BookmarkDto();
 				bookmarkDto.setVerseRange(verseRange);

--- a/and-bible/app/src/main/java/net/bible/android/view/activity/page/actionmode/VerseActionModeMediator.java
+++ b/and-bible/app/src/main/java/net/bible/android/view/activity/page/actionmode/VerseActionModeMediator.java
@@ -44,7 +44,7 @@ public class VerseActionModeMediator {
 
 	private ActionMode actionMode;
 
-    private static final String TAG = "VerseActionModeMediator";
+	private static final String TAG = "VerseActionModeMediator";
 
 	public VerseActionModeMediator(ActionModeMenuDisplay mainBibleActivity, VerseHighlightControl bibleView, PageControl pageControl, VerseMenuCommandHandler verseMenuCommandHandler, BookmarkControl bookmarkControl) {
 		this.mainBibleActivity = mainBibleActivity;
@@ -58,9 +58,9 @@ public class VerseActionModeMediator {
 	}
 
 	public void verseLongPress(int verse) {
-        Log.d(TAG, "Verse selected event:"+verse);
-        startVerseActionMode(verse);
-    }
+		Log.d(TAG, "Verse selected event:"+verse);
+		startVerseActionMode(verse);
+	}
 
 	/**
 	 * Handle selection and deselection of extra verses after initial verse
@@ -107,7 +107,7 @@ public class VerseActionModeMediator {
 		this.verseNoRange = new VerseNoRange(verse);
 		mainBibleActivity.showVerseActionModeMenu(actionModeCallbackHandler);
 		bibleView.enableVerseTouchSelection();
-    }
+	}
 
 	/**
 	 * Ensure all state is left tidy
@@ -162,10 +162,10 @@ public class VerseActionModeMediator {
 
 		@Override
 		public boolean onPrepareActionMode(ActionMode actionMode, Menu menu) {
-			// if start verse already bookmarked then enable Delete Bookmark menu item else Add Bookmark
+			// if start verse already bookmarked then enable Delete and Labels Bookmark menu item
 			Verse startVerse = getStartVerse();
 			boolean isVerseBookmarked = startVerse!=null && bookmarkControl.isBookmarkForKey(startVerse);
-			menu.findItem(R.id.add_bookmark).setVisible(!isVerseBookmarked);
+			menu.findItem(R.id.add_bookmark).setVisible(true);
 			menu.findItem(R.id.delete_bookmark).setVisible(isVerseBookmarked);
 			menu.findItem(R.id.edit_bookmark_labels).setVisible(isVerseBookmarked);
 

--- a/and-bible/app/src/main/java/net/bible/android/view/activity/page/actionmode/VerseMenuCommandHandler.java
+++ b/and-bible/app/src/main/java/net/bible/android/view/activity/page/actionmode/VerseMenuCommandHandler.java
@@ -65,7 +65,7 @@ public class VerseMenuCommandHandler {
 					break;
 				case R.id.add_bookmark:
 				case R.id.delete_bookmark:
-					bookmarkControl.toggleBookmarkForVerseRange(verseRange);
+					bookmarkControl.toggleBookmarkForVerseRange(menuItemId, verseRange);
 					// refresh view to show new bookmark icon
 					PassageChangeMediator.getInstance().forcePageUpdate();
 					isHandled = true;


### PR DESCRIPTION
We do this by showing the Add button also on selected verse even if it was bookmarked already. Adding it again will update the bookmark's date to the current time.

This is one of the changes suggested in [bookmark-improvements](https://github.com/mjdenham/and-bible/pull/111).

Example below. (The star indicates existing bookmark on this verse; the blue highlight indicates the verse was selected again - and the Add button is still shown at the top).

![image](https://user-images.githubusercontent.com/37398767/38778082-68e2c2be-40b3-11e8-9f7f-f052f8f5862b.png)
