### PR TITLE
Improve current book/chapter highlight in selection grid

### DIFF
--- a/and-bible/app/src/main/java/net/bible/android/view/util/buttongrid/ButtonGrid.java
+++ b/and-bible/app/src/main/java/net/bible/android/view/util/buttongrid/ButtonGrid.java
@@ -2,6 +2,7 @@ package net.bible.android.view.util.buttongrid;
 
 import android.content.Context;
 import android.graphics.Color;
+import android.graphics.Paint;
 import android.graphics.Typeface;
 import android.os.Build;
 import android.util.AttributeSet;
@@ -48,10 +49,10 @@ public class ButtonGrid extends TableLayout {
 	}
 
 	private ButtonInfo mCurrentPreview;
-    private TextView mPreviewText;
-    private PopupWindow mPreviewPopup;
-    private int mPreviewOffset;
-    private int mPreviewHeight;
+	private TextView mPreviewText;
+	private PopupWindow mPreviewPopup;
+	private int mPreviewOffset;
+	private int mPreviewHeight;
 	private static final int PREVIEW_HEIGHT_DIP = 70;
 	
 	private OnButtonGridActionListener onButtonGridActionListener;
@@ -67,39 +68,39 @@ public class ButtonGrid extends TableLayout {
 	private static final String TAG = "ButtonGrid";
 
 	public ButtonGrid(Context context) {
-        this(context, null, 0);
+		this(context, null, 0);
 	}
 
-    public ButtonGrid(Context context, AttributeSet attrs, int defStyle) {
-        super(context, attrs);
-        this.mContext = context;
+	public ButtonGrid(Context context, AttributeSet attrs, int defStyle) {
+		super(context, attrs);
+		this.mContext = context;
 
-        // use generic ViewGroup LayoutParams for Table because we don't know what the parent is
+		// use generic ViewGroup LayoutParams for Table because we don't know what the parent is
 		setLayoutParams(new ViewGroup.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
 		setStretchAllColumns(true);
-    }
-    
-    public void clear() {
-    	removeAllViews();
-    	buttonInfoList = null;
-    	mRowColLayout = null;
-    	mPressed = null;
-    	isInitialised = false;
-    }
-    
-    /** Called during initialisation to add the list of buttons to be laid out on the screen
-     * 
-     * @param buttonInfoList
-     */
-    public void addButtons(List<ButtonInfo> buttonInfoList) {
-    	this.buttonInfoList = buttonInfoList;
-    	int numButtons = buttonInfoList.size();
+	}
+
+	public void clear() {
+		removeAllViews();
+		buttonInfoList = null;
+		mRowColLayout = null;
+		mPressed = null;
+		isInitialised = false;
+	}
+
+	/** Called during initialisation to add the list of buttons to be laid out on the screen
+	 *
+	 * @param buttonInfoList
+	 */
+	public void addButtons(List<ButtonInfo> buttonInfoList) {
+		this.buttonInfoList = buttonInfoList;
+		int numButtons = buttonInfoList.size();
 		int textSize = getResources().getInteger(R.integer.grid_cell_text_size_sp);
-    	
-    	// calculate the number of rows and columns so that the grid looks nice
-    	mRowColLayout = new LayoutDesigner().calculateLayout(buttonInfoList); 
+
+		// calculate the number of rows and columns so that the grid looks nice
+		mRowColLayout = new LayoutDesigner().calculateLayout(buttonInfoList);
 		
-    	LayoutParams rowInTableLp = new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT, 1.0f);
+		LayoutParams rowInTableLp = new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT, 1.0f);
 		TableRow.LayoutParams cellInRowLp = new TableRow.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT, 1.0f);
 
 		for (int iRow=0; iRow<mRowColLayout.rows; iRow++) {
@@ -113,14 +114,15 @@ public class ButtonGrid extends TableLayout {
 					ButtonInfo buttonInfo = buttonInfoList.get(buttonInfoIndex);
 					Button button = new Button(mContext);
 					button.setText(buttonInfo.name);
+					button.setBackgroundResource(R.drawable.buttongrid_button_background);
+					button.setTextColor(buttonInfo.textColor);
 					if (buttonInfo.highlight) {
 						button.setTypeface(Typeface.DEFAULT_BOLD);
 						button.setTextSize(TypedValue.COMPLEX_UNIT_SP, textSize+1);
+						button.setPaintFlags(button.getPaintFlags() | Paint.UNDERLINE_TEXT_FLAG);
 					} else {
 						button.setTextSize(TypedValue.COMPLEX_UNIT_SP, textSize);
 					}
-					button.setBackgroundResource(R.drawable.buttongrid_button_background);
-					button.setTextColor(buttonInfo.textColor);
 					// set pad to 0 prevents text being pushed off the bottom of buttons on small screens
 					button.setPadding(0, 0, 0, 0);
 
@@ -147,26 +149,26 @@ public class ButtonGrid extends TableLayout {
 		mPreviewPopup.setContentView(mPreviewText);
 		mPreviewPopup.setBackgroundDrawable(null);
 		mPreviewPopup.setTouchable(false);
-        mPreviewText.setCompoundDrawables(null, null, null, null);
-        
-        float scale = mContext.getResources().getDisplayMetrics().density;
-        mPreviewHeight = (int)(PREVIEW_HEIGHT_DIP*scale);
+		mPreviewText.setCompoundDrawables(null, null, null, null);
+
+		float scale = mContext.getResources().getDisplayMetrics().density;
+		mPreviewHeight = (int)(PREVIEW_HEIGHT_DIP*scale);
 	}
 
-    /** Ensure longer runs by populating in longest direction ie columns if portrait and rows if landscape
-     * 
-     * @param row
-     * @param col
-     * @return
-     */
-    private int getButtonInfoIndex(int row, int col) {
-    	if (mRowColLayout.columnOrder) {
-    		return col*mRowColLayout.rows + row;
-    	} else {
-    		return row*mRowColLayout.cols + col;
-    	}
-    }
-    
+	/** Ensure longer runs by populating in longest direction ie columns if portrait and rows if landscape
+	 *
+	 * @param row
+	 * @param col
+	 * @return
+	 */
+	private int getButtonInfoIndex(int row, int col) {
+		if (mRowColLayout.columnOrder) {
+			return col*mRowColLayout.rows + row;
+		} else {
+			return row*mRowColLayout.cols + col;
+		}
+	}
+
 	/* (non-Javadoc)
 	 * @see android.view.ViewGroup#onInterceptTouchEvent(android.view.MotionEvent)
 	 */
@@ -184,20 +186,20 @@ public class ButtonGrid extends TableLayout {
 		}
 		
 		/*
-         * This method JUST determines whether we want to intercept the motion.
-         * If we return true, onMotionEvent will be called and we do the actual
-         * scrolling there.
-         */
+		 * This method JUST determines whether we want to intercept the motion.
+		 * If we return true, onMotionEvent will be called and we do the actual
+		 * scrolling there.
+		 */
 		return true;
 	}
 	
-    @Override
-    public boolean onTouchEvent(MotionEvent event) {
+	@Override
+	public boolean onTouchEvent(MotionEvent event) {
 
-    	switch (event.getAction()) {
-    	case MotionEvent.ACTION_DOWN :
-    	case MotionEvent.ACTION_MOVE :
-    		ButtonInfo but = findButton((int)event.getX(), (int)event.getY());
+		switch (event.getAction()) {
+		case MotionEvent.ACTION_DOWN :
+		case MotionEvent.ACTION_MOVE :
+			ButtonInfo but = findButton((int)event.getX(), (int)event.getY());
 			if (but!=null) {
 				// show the button being pressed
 				if (!but.equals(mPressed)) {
@@ -210,33 +212,33 @@ public class ButtonGrid extends TableLayout {
 				}
 			}
 			break;
-    	case MotionEvent.ACTION_UP :
-    		if (mPressed!=null) {
-    			buttonSelected(mPressed);
-    		}
-    		break;
-    	}
-    	
+		case MotionEvent.ACTION_UP :
+			if (mPressed!=null) {
+				buttonSelected(mPressed);
+			}
+			break;
+		}
+
 		return true; //super.onInterceptTouchEvent(ev);
 	}
 
-    private ButtonInfo findButton(int x, int y) {
+	private ButtonInfo findButton(int x, int y) {
 		for (ButtonInfo but : buttonInfoList) {
 			if (isInside(but, x, y)) {
 				return but;
 			}
 		}
 		return null;
-    }
-    
-    private void buttonSelected(ButtonInfo selectedButton) {
-    	Log.i(TAG, "Selected:"+selectedButton.name);
-    	if (onButtonGridActionListener!=null) {
-    		onButtonGridActionListener.buttonPressed(selectedButton);
-    	}
-    	
-    	close();    	
-    }
+	}
+
+	private void buttonSelected(ButtonInfo selectedButton) {
+		Log.i(TAG, "Selected:"+selectedButton.name);
+		if (onButtonGridActionListener!=null) {
+			onButtonGridActionListener.buttonPressed(selectedButton);
+		}
+
+		close();
+	}
 	
 	private boolean isInside(ButtonInfo but, float x, float y) {
 		return (but.top<y && but.bottom>y &&
@@ -250,44 +252,44 @@ public class ButtonGrid extends TableLayout {
 				mCurrentPreview = buttonInfo;
 				mPreviewText.setText(buttonInfo.name);
 	
-	            int popupHeight = mPreviewHeight;
-	            mPreviewText.measure(MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED), MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED));
-	            int popupWidth = Math.max(mPreviewText.getMeasuredWidth(), buttonInfo.button.getWidth() + mPreviewText.getPaddingLeft() + mPreviewText.getPaddingRight());
+				int popupHeight = mPreviewHeight;
+				mPreviewText.measure(MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED), MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED));
+				int popupWidth = Math.max(mPreviewText.getMeasuredWidth(), buttonInfo.button.getWidth() + mPreviewText.getPaddingLeft() + mPreviewText.getPaddingRight());
 	
-	            ViewGroup.LayoutParams lp = mPreviewText.getLayoutParams();
-	            if (lp != null) {
-	                lp.width = popupWidth;
-	                lp.height = popupHeight;
-	            }
+				ViewGroup.LayoutParams lp = mPreviewText.getLayoutParams();
+				if (lp != null) {
+					lp.width = popupWidth;
+					lp.height = popupHeight;
+				}
 	
-	            // where to place the popup
-	            int popupPreviewX;
-	            int popupPreviewY;
-	            if (buttonInfo.rowNo<2) {
-	        		int horizontalOffset = (2*buttonInfo.button.getWidth());
-	    			// if in top 2 rows then show off to right/left to avoid popup going off the screen
-	            	if (buttonInfo.colNo<mRowColLayout.cols/2.0) {
-	            		// key is on left so show to right of key
-	        			popupPreviewX = buttonInfo.left - mPreviewText.getPaddingLeft() + horizontalOffset;
-	            	} else {
-	            		// key is on right so show to right of key
-	        			popupPreviewX = buttonInfo.left - mPreviewText.getPaddingLeft() - horizontalOffset;
-	            	}
-	                popupPreviewY = buttonInfo.bottom;
-	            } else {
-	            	// show above the key above the one currently pressed 
-	    			popupPreviewX = buttonInfo.left - mPreviewText.getPaddingLeft();
-	                popupPreviewY = buttonInfo.top /*- popupHeight*/+ mPreviewOffset;
-	            }
+				// where to place the popup
+				int popupPreviewX;
+				int popupPreviewY;
+				if (buttonInfo.rowNo<2) {
+					int horizontalOffset = (2*buttonInfo.button.getWidth());
+					// if in top 2 rows then show off to right/left to avoid popup going off the screen
+					if (buttonInfo.colNo<mRowColLayout.cols/2.0) {
+						// key is on left so show to right of key
+						popupPreviewX = buttonInfo.left - mPreviewText.getPaddingLeft() + horizontalOffset;
+					} else {
+						// key is on right so show to right of key
+						popupPreviewX = buttonInfo.left - mPreviewText.getPaddingLeft() - horizontalOffset;
+					}
+					popupPreviewY = buttonInfo.bottom;
+				} else {
+					// show above the key above the one currently pressed
+					popupPreviewX = buttonInfo.left - mPreviewText.getPaddingLeft();
+					popupPreviewY = buttonInfo.top /*- popupHeight*/+ mPreviewOffset;
+				}
 				
-	            if (mPreviewPopup.isShowing()) {
-	                mPreviewPopup.update(popupPreviewX, popupPreviewY, popupWidth, popupHeight);
-	            } else {
-	            	mPreviewPopup.setWidth(popupWidth);
-	                mPreviewPopup.setHeight(popupHeight);
-	                mPreviewPopup.showAtLocation(this, Gravity.NO_GRAVITY, popupPreviewX, popupPreviewY);
-	            }
-	            mPreviewText.setVisibility(VISIBLE);
+				if (mPreviewPopup.isShowing()) {
+					mPreviewPopup.update(popupPreviewX, popupPreviewY, popupWidth, popupHeight);
+				} else {
+					mPreviewPopup.setWidth(popupWidth);
+					mPreviewPopup.setHeight(popupHeight);
+					mPreviewPopup.showAtLocation(this, Gravity.NO_GRAVITY, popupPreviewX, popupPreviewY);
+				}
+				mPreviewText.setVisibility(VISIBLE);
 			} else {
 				// could be returning to this view via Back or Finish and the user represses same button 
 				if (mPreviewText.getVisibility()!=VISIBLE) { 
@@ -300,14 +302,14 @@ public class ButtonGrid extends TableLayout {
 		}
 	}
 	
-    @Override
+	@Override
 	protected void onDetachedFromWindow() {
-    	close();
-    	
+		close();
+
 		super.onDetachedFromWindow();
 	}
-    
-    private void close() {
+
+	private void close() {
 		// avoid errors on Lenovo tablet in dismiss
 		try {
 			if (mPreviewPopup.isShowing()) {
@@ -316,11 +318,11 @@ public class ButtonGrid extends TableLayout {
 		} catch (Exception e) {
 			Log.w(TAG, "Error closing ButtonGrid preview");
 		}
-    }
-    
+	}
+
 	/** calculate button position relative to this table because MotionEvents are relative to this table
-     */
-    private void recordButtonPositions() {
+	 */
+	private void recordButtonPositions() {
 		for (ButtonInfo buttonInfo : buttonInfoList) {
 			
 			// get position of button within row
@@ -338,7 +340,7 @@ public class ButtonGrid extends TableLayout {
 			ButtonInfo but1 = buttonInfoList.get(0);
 			mPreviewOffset = but1.top - but1.bottom;
 		}
-    }
+	}
 	/**
 	 * @param onButtonGridActionListener the onButtonGridActionListener to set
 	 */


### PR DESCRIPTION
 Improve the highlight of the current book or chapter in the book and chapter selection grid by underlining the name/chapter. (Why: It is difficult to see the current item otherwise, and it helps to quickly locate the current book on the grid. If you re-select it you can change the chapter.)

This is one of the changes suggested in [bookmark-improvements](https://github.com/mjdenham/and-bible/pull/111).

Examples below:
![image](https://user-images.githubusercontent.com/37398767/38778168-6c3d0ca6-40b5-11e8-9b38-947dcf0b4786.png)

and

![image](https://user-images.githubusercontent.com/37398767/38778176-8ee86606-40b5-11e8-9347-a47a8b82a01b.png)

