### PR TITLE
Bugfix/improvement: Force synchronize windows if adding/deleting bookmark

### DIFF
--- a/and-bible/app/src/main/java/net/bible/android/control/bookmark/BookmarkControl.java
+++ b/and-bible/app/src/main/java/net/bible/android/control/bookmark/BookmarkControl.java
@@ -6,9 +6,11 @@ import android.support.design.widget.Snackbar;
 import android.util.Log;
 import android.view.View;
 
+import de.greenrobot.event.EventBus;
 import net.bible.android.activity.R;
 import net.bible.android.common.resource.ResourceProvider;
 import net.bible.android.control.ApplicationScope;
+import net.bible.android.control.event.passage.BookmarkChangedEvent;
 import net.bible.android.control.page.CurrentBiblePage;
 import net.bible.android.control.page.CurrentPageManager;
 import net.bible.android.control.page.window.ActiveWindowPageManagerProvider;
@@ -99,6 +101,7 @@ public class BookmarkControl {
 				}
 			}
 		}
+		EventBus.getDefault().post(new BookmarkChangedEvent());
 		return bOk;
 	}
 

--- a/and-bible/app/src/main/java/net/bible/android/control/event/passage/BookmarkChangedEvent.java
+++ b/and-bible/app/src/main/java/net/bible/android/control/event/passage/BookmarkChangedEvent.java
@@ -1,0 +1,12 @@
+package net.bible.android.control.event.passage;
+
+/**
+ * The verse has changed.
+ * 
+ * @author Martin Denham [mjdenham at gmail dot com]
+ * @see gnu.lgpl.License for license details.<br>
+ *      The copyright to this program is held by it's author.
+ */
+public class BookmarkChangedEvent {
+
+}

--- a/and-bible/app/src/main/java/net/bible/android/control/page/window/WindowControl.java
+++ b/and-bible/app/src/main/java/net/bible/android/control/page/window/WindowControl.java
@@ -8,6 +8,7 @@ import net.bible.android.BibleApplication;
 import net.bible.android.activity.R;
 import net.bible.android.control.ApplicationScope;
 import net.bible.android.control.event.EventManager;
+import net.bible.android.control.event.passage.BookmarkChangedEvent;
 import net.bible.android.control.event.passage.CurrentVerseChangedEvent;
 import net.bible.android.control.event.window.NumberOfWindowsChangedEvent;
 import net.bible.android.control.event.window.WindowSizeChangedEvent;
@@ -288,7 +289,12 @@ public class WindowControl implements ActiveWindowPageManagerProvider {
 	public void onEvent(CurrentVerseChangedEvent event) {
 		windowSync.synchronizeScreens();
 	}
-	
+
+	public void onEvent(BookmarkChangedEvent event) {
+		windowSync.setResynchRequired(true);
+		windowSync.synchronizeScreens();
+	}
+
 	public boolean isMultiWindow() {
 		return windowRepository.isMultiWindow();
 	}


### PR DESCRIPTION
Issue description:
- open 2 bible windows
- Create bookmark in first window
- Actual: bookmark is visible in first window, but not the second
- Expected: bookmark is visible in both windows.

This PR fixes the issue.
