### PR TITLE
Bugfix: Do not synchronize general books or unsynchronized commentaries

### DIFF
--- a/and-bible/app/src/main/java/net/bible/android/control/page/window/WindowSync.java
+++ b/and-bible/app/src/main/java/net/bible/android/control/page/window/WindowSync.java
@@ -123,6 +123,10 @@ public class WindowSync {
 			}
 			
 			Verse currentVerse = null;
+			boolean isGeneralBook = BookCategory.GENERAL_BOOK.equals(inactivePage.getCurrentDocument().getBookCategory());
+			boolean isUnsynchronizedCommentary = !inactiveWindow.isSynchronised()
+					&& BookCategory.COMMENTARY.equals(inactivePage.getCurrentDocument().getBookCategory());
+
 			if (inactiveWindowKey!=null && inactiveWindowKey instanceof Verse) {
 				currentVerse = KeyUtil.getVerse(inactiveWindowKey);
 			}
@@ -132,7 +136,12 @@ public class WindowSync {
 					BookCategory.BIBLE.equals(inactivePage.getCurrentDocument().getBookCategory()) && 
 					currentVerse!=null && targetVerse!=null && targetV11n.isSameChapter(targetVerse, currentVerse)) {
 				EventBus.getDefault().post(new ScrollSecondaryWindowEvent(inactiveWindow, targetVerse.getVerse()));
-			} else {
+			}
+			else if(isGeneralBook || isUnsynchronizedCommentary)
+			{
+				// Do not update! Updating would reset page position.
+			}
+			else {
 				new UpdateInactiveScreenTextTask().execute(inactiveWindow);
 			}
 		}


### PR DESCRIPTION
Issue description:
1)
- Open two windows, 1 for bible, 1 for general book with a long page.
- Go to the bottom of the general book page.
- Resize bible window.
Actual: Due to refresh, general book page goes to the beginning. 
Expected: General book page does not change.

2) 
- Open two windows, 1 for bible, 1 for commentary. 
- Switch off commentary window synchronization
- Open a long page in commentary window and go to the bottom of the window
- Resize bible window.
Actual: Due to refresh, commentary page goes to the beginning. 
Expected: Commentary page in this case should not change. 

This PR fixes this issue.