### PR TITLE
If long-clicking on normal text (not link) do not open context menu open previous link.

### DIFF
--- a/and-bible/app/src/main/java/net/bible/android/view/activity/page/BibleView.java
+++ b/and-bible/app/src/main/java/net/bible/android/view/activity/page/BibleView.java
@@ -614,7 +614,10 @@ public class BibleView extends WebView implements DocumentView, VerseActionModeM
 				setContextMenuInfo(result.getExtra());
 				return v.showContextMenu();
 			}
-			return defaultValue;
+			else {
+				contextMenuInfo = null;
+				return defaultValue;
+			}
 		}
 	}
 


### PR DESCRIPTION
Found issue in develop related to the new context menu feature (#114):

1. Long-click link (in a commentary for example). Context menu opens normally. Close menu without clicking any menu entry (by clicking on gray area instead).
 2. Long-click on text which doesn't have link.
-> Expected: text selector should activate and not context menu.
-> Actual: context menu appears.

This PR fixes the issue, which is caused by context menu info that is not reset properly.