### PR TITLE
Bugfix/app restarts after assigning bookmark label

### DIFF
--- a/and-bible/app/src/main/java/net/bible/android/control/bookmark/BookmarkControl.java
+++ b/and-bible/app/src/main/java/net/bible/android/control/bookmark/BookmarkControl.java
@@ -14,6 +14,7 @@ import net.bible.android.control.event.passage.BookmarkChangedEvent;
 import net.bible.android.control.page.CurrentBiblePage;
 import net.bible.android.control.page.CurrentPageManager;
 import net.bible.android.control.page.window.ActiveWindowPageManagerProvider;
+import net.bible.android.view.activity.base.ActivityBase;
 import net.bible.android.view.activity.base.CurrentActivityHolder;
 import net.bible.android.view.activity.base.Dialogs;
 import net.bible.android.view.activity.base.IntentHelper;
@@ -439,6 +440,6 @@ public class BookmarkControl {
 		// Show label view for new bookmark
 		final Intent intent = new Intent(currentActivity, BookmarkLabels.class);
 		intent.putExtra(BOOKMARK_IDS_EXTRA, new long[] {bookmarkDto.getId()});
-		currentActivity.startActivityForResult(intent, IntentHelper.REFRESH_DISPLAY_ON_FINISH);
+		currentActivity.startActivityForResult(intent, ActivityBase.STD_REQUEST_CODE);
 	}
 }

--- a/and-bible/app/src/main/java/net/bible/android/view/activity/page/MenuCommandHandler.java
+++ b/and-bible/app/src/main/java/net/bible/android/view/activity/page/MenuCommandHandler.java
@@ -99,8 +99,6 @@ public class MenuCommandHandler {
 		        	break;
 				case (R.id.manageLabels):
 					handlerIntent = new Intent(callingActivity, ManageLabels.class);
-					mPrevLocalePref = CommonUtils.getLocalePref();
-					requestCode = IntentHelper.REFRESH_DISPLAY_ON_FINISH;
 					break;
 		        case R.id.mynotesButton:
 		        	handlerIntent = new Intent(callingActivity, MyNotes.class);


### PR DESCRIPTION
Bug description:
- go to settings and change application language to "English" (or anything else but not "Default").
- add bookmark
- click "Assign labels" button that appears in the bottom (before it disappears)
- click OK
-> Expected: return to main screen without restart
-> Actual: App restarts unnecessarily.

This PR fixes this issue. This does not seem regression but older issue.
When debugging this I found also 2 lines of code which did not make any sense (commit 
c92e18b), but did not cause any issue either. I cleaned it up a little and checked that it did not break.