### PR TITLE
Fix window synchronization related problems

### DIFF
--- a/and-bible/app/src/main/java/net/bible/android/control/bookmark/BookmarkControl.java
+++ b/and-bible/app/src/main/java/net/bible/android/control/bookmark/BookmarkControl.java
@@ -10,7 +10,7 @@ import de.greenrobot.event.EventBus;
 import net.bible.android.activity.R;
 import net.bible.android.common.resource.ResourceProvider;
 import net.bible.android.control.ApplicationScope;
-import net.bible.android.control.event.passage.BookmarkChangedEvent;
+import net.bible.android.control.event.passage.SynchronizeWindowsEvent;
 import net.bible.android.control.page.CurrentBiblePage;
 import net.bible.android.control.page.CurrentPageManager;
 import net.bible.android.control.page.window.ActiveWindowPageManagerProvider;
@@ -107,6 +107,7 @@ public class BookmarkControl {
 				Dialogs.getInstance().showErrorMsg(R.string.error_occurred);
 			}
 		}
+		EventBus.getDefault().post(new SynchronizeWindowsEvent());
 		return bOk;
 	}
 
@@ -125,7 +126,7 @@ public class BookmarkControl {
 				}
 			}
 		}
-		EventBus.getDefault().post(new BookmarkChangedEvent());
+		EventBus.getDefault().post(new SynchronizeWindowsEvent());
 		return bOk;
 	}
 

--- a/and-bible/app/src/main/java/net/bible/android/control/event/passage/SynchronizeWindowsEvent.java
+++ b/and-bible/app/src/main/java/net/bible/android/control/event/passage/SynchronizeWindowsEvent.java
@@ -7,6 +7,6 @@ package net.bible.android.control.event.passage;
  * @see gnu.lgpl.License for license details.<br>
  *      The copyright to this program is held by it's author.
  */
-public class BookmarkChangedEvent {
+public class SynchronizeWindowsEvent {
 
 }

--- a/and-bible/app/src/main/java/net/bible/android/control/page/window/WindowControl.java
+++ b/and-bible/app/src/main/java/net/bible/android/control/page/window/WindowControl.java
@@ -8,7 +8,7 @@ import net.bible.android.BibleApplication;
 import net.bible.android.activity.R;
 import net.bible.android.control.ApplicationScope;
 import net.bible.android.control.event.EventManager;
-import net.bible.android.control.event.passage.BookmarkChangedEvent;
+import net.bible.android.control.event.passage.SynchronizeWindowsEvent;
 import net.bible.android.control.event.passage.CurrentVerseChangedEvent;
 import net.bible.android.control.event.window.NumberOfWindowsChangedEvent;
 import net.bible.android.control.event.window.WindowSizeChangedEvent;
@@ -300,7 +300,7 @@ public class WindowControl implements ActiveWindowPageManagerProvider {
 		windowSync.synchronizeScreens();
 	}
 
-	public void onEvent(BookmarkChangedEvent event) {
+	public void onEvent(SynchronizeWindowsEvent event) {
 		windowSync.setResynchRequired(true);
 		windowSync.synchronizeScreens();
 	}

--- a/and-bible/app/src/main/java/net/bible/android/view/activity/base/IntentHelper.java
+++ b/and-bible/app/src/main/java/net/bible/android/view/activity/base/IntentHelper.java
@@ -26,6 +26,8 @@ public class IntentHelper {
 
 	public static final int UPDATE_SUGGESTED_DOCUMENTS_ON_FINISH = 3;
 
+	public static final int RESTART_REQUIRED = 4;
+
 	private static final String VERSE_RANGE = "net.bible.android.view.activity.comparetranslations.VerseRange";
 
 	private static final String TAG = "IntentHelper";

--- a/and-bible/app/src/main/java/net/bible/android/view/activity/page/MainBibleActivity.java
+++ b/and-bible/app/src/main/java/net/bible/android/view/activity/page/MainBibleActivity.java
@@ -22,6 +22,7 @@ import net.bible.android.control.BibleContentManager;
 import net.bible.android.control.PassageChangeMediator;
 import net.bible.android.control.backup.BackupControl;
 import net.bible.android.control.event.apptobackground.AppToBackgroundEvent;
+import net.bible.android.control.event.passage.SynchronizeWindowsEvent;
 import net.bible.android.control.event.passage.PassageChangeStartedEvent;
 import net.bible.android.control.event.passage.PassageChangedEvent;
 import net.bible.android.control.event.passage.PreBeforeCurrentPageChangeEvent;
@@ -242,6 +243,7 @@ public class MainBibleActivity extends CustomTitlebarActivityBase implements Ver
 			// restart done in above
 		} else if (mainMenuCommandHandler.isDisplayRefreshRequired(requestCode)) {
 			preferenceSettingsChanged();
+			EventBus.getDefault().post(new SynchronizeWindowsEvent());
 		} else if (mainMenuCommandHandler.isDocumentChanged(requestCode)) {
 			updateActionBarButtons();
 		}

--- a/and-bible/app/src/main/java/net/bible/android/view/activity/page/MenuCommandHandler.java
+++ b/and-bible/app/src/main/java/net/bible/android/view/activity/page/MenuCommandHandler.java
@@ -89,7 +89,7 @@ public class MenuCommandHandler {
 		        	handlerIntent = new Intent(callingActivity, SettingsActivity.class);
 		        	// force the bible view to be refreshed after returning from settings screen because notes, verses, etc. may be switched on or off
 		        	mPrevLocalePref = CommonUtils.getLocalePref();
-		        	requestCode = IntentHelper.REFRESH_DISPLAY_ON_FINISH;
+		        	requestCode = IntentHelper.RESTART_REQUIRED;
 		        	break;
 		        case R.id.historyButton:
 		        	handlerIntent = new Intent(callingActivity, History.class);
@@ -153,7 +153,7 @@ public class MenuCommandHandler {
     }
     
     public boolean restartIfRequiredOnReturn(int requestCode) {
-    	if (requestCode == IntentHelper.REFRESH_DISPLAY_ON_FINISH) {
+    	if (requestCode == IntentHelper.RESTART_REQUIRED) {
     		Log.i(TAG, "Refresh on finish");
     		if (!CommonUtils.getLocalePref().equals(mPrevLocalePref)) {
     			// must restart to change locale


### PR DESCRIPTION
There was regression (from 9b40cf362a840193cd302365505f2bad3507ccae) that caused issue fixed by #122 reappear. This fixes that again and tries to make window synchronization code more clear.

- Rename BookmarkChangedEvent to SynchronizeWindowsEvent which can be triggered when window sync is needed.

- Create new request code RESTART_REQUIRED to IntentHelper for settings window changes.